### PR TITLE
Fix production php dockerfile

### DIFF
--- a/php/production/Dockerfile
+++ b/php/production/Dockerfile
@@ -33,3 +33,6 @@ COPY --chown="$USER":"$USER" . /var/www/html
 
 # switch to created user
 USER "$USER"
+
+# install dependencies
+RUN composer install --no-dev


### PR DESCRIPTION
Added `composer install --no-dev` to php production dockerfile to install vendor dependencies.